### PR TITLE
Add comment for build at MinGW or MSYS.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,6 +33,10 @@ OBJS =	calc.o doscall.o exec.o getini.o iocscall.o key.o \
 CC = gcc
 
 #LDFLAGS = -lc -lcygwin -lm -lg -lmsvcrt40
+# for MinGW
+#LDFLAGS = -lmsvcrt40
+# for MSYS
+#LDFLAGS =
 LDFLAGS = -lcygwin -lmsvcrt40
 DEFS = -DFNC_TRACE -DENV_FROM_INI
 CFLAGS = -g $(DEFS)


### PR DESCRIPTION
[issue]
手持ちのMinGWとMSYS(msys64-2016-02-16)でビルドする際、ビルドエラーになりました。
At build on MinGW or MSYS, an error has occurred .

[improved]
At build on MinGW, delete "-lcygwin" from makefile.
At build on MSYS, delete "-lcygwin -lmsvcrt40" from makefile.
I add them to makefile as a comment .

MinGWでのビルドではmakefileから"-lcygwin"を削除することで、ビルド成功しました。
MSYSでのビルドではmakefileから"-lcygwin -lmsvcrt40"を削除することで、ビルド成功しました。
今後誰かが同様の環境でビルドを行う際の参考に、
makefileにコメントとして追加しました。
